### PR TITLE
frontend: Prevent potential NPE

### DIFF
--- a/frontend/search.go
+++ b/frontend/search.go
@@ -460,6 +460,7 @@ func (f *Frontend) searchResults(d data, lang language.Tag, region language.Regi
 	sr, err := f.Search.Fetch(d.Context.Q, d.Context.F, lang, region, d.Context.Number, offset)
 	if err != nil {
 		log.Info.Println(err)
+		return &search.Results{}
 	}
 
 	sr = sr.AddPagination(d.Context.Number, d.Context.Page) // move this to javascript??? (Wouldn't be available in API....)


### PR DESCRIPTION
When search error is returned, the code will still try to call `search.Results.AddPagination` on a nil pointer, leading to NPE.

This change Fixes it by returning an empty result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jivesearch/jivesearch/109)
<!-- Reviewable:end -->
